### PR TITLE
Add conditional_bdm to compute BDM(x|y)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,3 +26,4 @@ doctest_plus = enabled
 filterwarnings =
     ignore:CTM dataset does not contain object
     ignore:Using or importing the ABCs
+    

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 """*PyTest* configuration and general purpose fixtures."""
 import pytest
 from pybdm import BDM
-from pybdm.partitions import PartitionRecursive
+from pybdm.partitions import PartitionCorrelated, PartitionRecursive
 
 
 def pytest_addoption(parser):
@@ -51,3 +51,7 @@ def bdm_d2():
 @pytest.fixture(scope='session')
 def bdm_d1_b9():
     return BDM(ndim=1, nsymbols=9, partition=PartitionRecursive, min_length=1)
+
+@pytest.fixture(scope='session')
+def bdm_d1_collapse3():
+    return BDM(ndim=1, partition=PartitionCorrelated, shift=3)

--- a/tests/test_bdm.py
+++ b/tests/test_bdm.py
@@ -162,6 +162,14 @@ class TestBDM:
         output = bdm_d2.nent(X)
         assert output == approx(expected)
 
+    @pytest.mark.parametrize('X,Y,expected', [
+        (array_from_string('010101010101010101111', shape=(21,)), array_from_string('010', shape=(3,)), 14.071500815885443),
+        (array_from_string('010101010101010101111', shape=(21,)), array_from_string('000', shape=(3,)), 19.57688365108973),
+    ])
+    def test_conditional_bdm(self, bdm_d1_collapse3, X, Y, expected):
+        output = bdm_d1_collapse3.conditional_bdm(X, Y)
+        assert output == approx(expected)
+
     @pytest.mark.slow
     def test_bdm_parallel(self, bdm_d2):
         X = np.ones((500, 500), dtype=int)

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,11 @@
 [tox]
 envlist = py35, py36, py37, style, docs
 
+[pytest]
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')
+    serial
+
 [testenv]
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/pybdm


### PR DESCRIPTION
- add `conditional_bdm(X,Y)` and `test_conditional_bdm` based on
  supplementary from [Hernández-Orozco S, Zenil H, (2021)](https://doi.org/10.3389/frai.2020.567356)
- add compute_f_of_intersect used in Coarse Conditional BDM
  to compute ![f(n_xj,n_yj)](http://www.sciweavers.org/tex2img.php?eq=%20f%20%5Cbig%28n%5Ex_j%2C%20n%5Ey_j%5Cbig%29&bc=White&fc=Black&im=jpg&fs=12&ff=modern&edit=0)
- add pytest mark for slow in `tox.ini`